### PR TITLE
setThistoOld_has_been_updated

### DIFF
--- a/src/Components/SimpleList/index.js
+++ b/src/Components/SimpleList/index.js
@@ -10,7 +10,7 @@ const SimpleList = ({simpleList, clickEntry}) => {
           {simpleList.map(function (
             prodObj
           ) {
-              return (<StyledSimpleEntry onClick={()=>clickEntry(prodObj.id)}> 
+              return (<StyledSimpleEntry onClick={()=>clickEntry(prodObj)}> 
 {/* <p>{prodObj.data}</p>  */}
 
 {prodObj.data.map(element => {

--- a/src/ProductsPage.js
+++ b/src/ProductsPage.js
@@ -199,37 +199,25 @@ const ProductsPage = (props) => {
     // setDoc(specialOfTheDay, docData);
   };
 const setThisToOldList = async (props) =>{
-  let path = "dailySpecial/" + props;
-  const specialOfTheDay = doc(firestore, path);
-  const mySnapshot = await getDoc(specialOfTheDay);
-  if(mySnapshot.exists()){
-    const docData = mySnapshot.data();
-    console.log('docData is' + JSON.stringify(docData));
-  
- 
+
+
+
+
+    const docData = props.data;
+
 
     const maybeArray = [];
-    const tempArray = [];
+
     var result = Object.keys(docData);
     var resultVal = Object.values(docData);
-    var resultVal2 = Object.values(docData).map((key) => [docData[key], docData[key]]);
-    var resultEntries = Object.entries(docData);
-    var result2 = result.map((key) => [Number(key), docData[key], docData[key]]);
-    var result3 = resultVal.map((key) => [Number(key), docData[key], docData[key]]);
+
+
     result.forEach((doc) => {
       // doc.data() is never undefined for query doc snapshots
       maybeArray.push(doc.entries);
 
     });
-console.log("this is the weird Object.keys(docData) " + result);
-console.log("this is the weird result2! " + result2);
-console.log("this is the weird resultVal! " + resultVal);
 
-console.log("this is the weird resultVal2! " + resultVal);
-console.log("this is the weird result3! " + result3);
-console.log("this is the weird Object.entries(docData)! " + resultEntries);
-console.log("this is the ProduclistSelected! " + productListSelected);
-console.log("this is the weird array " + maybeArray);
  
 
 
@@ -245,7 +233,7 @@ console.log("this is the weird array " + maybeArray);
       setProductListSelected(JSON.parse(localStorage.getItem("selectedproducts") || "[]"));
       postProducts(newProducts);
 
-  }
+  
 };
   const testSetLists = () => {
     const newEntry= JSON.parse(localStorage.getItem("selectedproducts") || "[]")


### PR DESCRIPTION
SetThisToOld has been updated so it uses props.data instead of calling the API to get the data. 
This means that SimpleList also has been updated. it longer sends ProdObj.id as a prop. now it just sends ProdObj.
This helps performance. It also makes more sense in the code. we just pass the ProdObj around and then use the bits we need in each funtion.